### PR TITLE
[SPARK-52831] Revise the default logging layout to include only name …

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -176,7 +176,7 @@ operatorConfiguration:
     appender.console.name = console
     appender.console.target = SYSTEM_ERR
     appender.console.layout.type = PatternLayout
-    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X %C{1.} [%t] %m%n%ex
+    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X{resource.name} %X{resource.namespace} %C{1.} %m%n%ex
   spark-operator.properties: |+
     # Property Overrides. e.g.
     # spark.kubernetes.operator.reconciler.intervalSeconds=60


### PR DESCRIPTION
…& namespace MDC Keys

### What changes were proposed in this pull request?

This PR updates the default layout in operator helm chart, to make it include only the resource name and namespace MDC keys instead of all

### Why are the changes needed?

The current logging is extremely verbose by default:

```
25/07/16 22:47:03 INFO {resource.apiVersion=spark.apache.org/v1, resource.app.attemptId=0, resource.generation=2, resource.kind=SparkApplication, resource.name=test-00553, resource.namespace=default, resource.resourceVersion=77206, resource.uid=c8c40a69-7397-4230-8bef-701c25436b54} o.a.s.k.o.r.SparkAppReconciler [ReconcilerExecutor-sparkappreconciler-73] Cleaning up resources for SparkApp:test-00553
25/07/16 22:47:03 INFO {resource.apiVersion=spark.apache.org/v1, resource.app.attemptId=0, resource.generation=2, resource.kind=SparkApplication, resource.name=test-00554, resource.namespace=default, resource.resourceVersion=77208, resource.uid=e007ca5f-94c0-4c30-8e1e-543aafb65c67} o.a.s.k.o.r.SparkAppReconciler [ReconcilerExecutor-sparkappreconciler-52] Cleaning up resources for SparkApp:test-00554
25/07/16 22:47:03 INFO {resource.apiVersion=spark.apache.org/v1, resource.app.attemptId=0, resource.generation=2, resource.kind=SparkApplication, resource.name=test-00555, resource.namespace=default, resource.resourceVersion=77211, resource.uid=7ea87cb4-6dca-43be-be08-ac9dca335912} o.a.s.k.o.r.SparkAppReconciler [ReconcilerExecutor-sparkappreconciler-69] Cleaning up resources for SparkApp:test-00555

```

With this patch, logging would include only resource name and namespace (which are most critical)

```
25/07/16 16:18:35 INFO {resource.name=pi, resource.namespace=default} o.a.s.k.o.r.SparkAppReconciler Cleaning up resources for SparkApp:pi
```

users may still override the values to include more keys as needed. This is to make sure we have informational and concise logging by default.

### Does this PR introduce _any_ user-facing change?

Logging enhancements expected for operator

### How was this patch tested?

CIs for lint, and validated logging in dev environments

### Was this patch authored or co-authored using generative AI tooling?

No

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
