### PR TITLE
[SPARK-59092] Honor Retry-After when retrying secondary resource crea…

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/BackoffUtils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/BackoffUtils.java
@@ -22,7 +22,11 @@ package org.apache.spark.k8s.operator.utils;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.*;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.StatusDetails;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.extern.slf4j.Slf4j;
 
 /** Utility class for exponential backoff with jitter on retryable API errors. */
@@ -32,32 +36,68 @@ public final class BackoffUtils {
   private BackoffUtils() {}
 
   /**
-   * Sleeps with jitter exponential backoff before retrying resource creation.
+   * Sleeps before retrying resource creation. Honors the server-provided retryAfterSeconds
+   * (surfaced from the HTTP {@code Retry-After} header by the Kubernetes API server) when
+   * present, otherwise falls back to jitter exponential backoff.
    *
    * @see <a href="https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/">
    *     Exponential Backoff and Jitter</a>
    */
-  public static void backoffSleep(int responseCode, long attemptCount, long maxAttempts) {
-    long initialBackoffMs = API_SECONDARY_RESOURCE_CREATE_INITIAL_BACKOFF_MILLIS.getValue();
-    long maxBackoffMs = API_SECONDARY_RESOURCE_CREATE_MAX_BACKOFF_MILLIS.getValue();
-    double backoffMultiplier = API_SECONDARY_RESOURCE_CREATE_BACKOFF_MULTIPLIER.getValue();
-    long jitterMs = API_SECONDARY_RESOURCE_CREATE_BACKOFF_JITTER_MILLIS.getValue();
-    long actualDelay =
-        computeBackoffDelay(
-            initialBackoffMs, backoffMultiplier, attemptCount, maxBackoffMs, jitterMs);
-    log.info(
-        "Retrying resource creation with exponential backoff. "
-            + "Delay: {}ms, responseCode: {}, attempt: {}/{}",
-        actualDelay,
-        responseCode,
-        attemptCount,
-        maxAttempts);
+  public static void backoffSleep(
+      KubernetesClientException e, long attemptCount, long maxAttempts) {
+    Long retryAfterMillis = getRetryAfterMillis(e);
+    long actualDelay;
+    if (retryAfterMillis != null) {
+      actualDelay = retryAfterMillis;
+      log.info(
+          "Retrying resource creation honoring server Retry-After. "
+              + "Delay: {}ms, responseCode: {}, attempt: {}/{}",
+          actualDelay,
+          e.getCode(),
+          attemptCount,
+          maxAttempts);
+    } else {
+      long initialBackoffMs = API_SECONDARY_RESOURCE_CREATE_INITIAL_BACKOFF_MILLIS.getValue();
+      long maxBackoffMs = API_SECONDARY_RESOURCE_CREATE_MAX_BACKOFF_MILLIS.getValue();
+      double backoffMultiplier = API_SECONDARY_RESOURCE_CREATE_BACKOFF_MULTIPLIER.getValue();
+      long jitterMs = API_SECONDARY_RESOURCE_CREATE_BACKOFF_JITTER_MILLIS.getValue();
+      actualDelay =
+          computeBackoffDelay(
+              initialBackoffMs, backoffMultiplier, attemptCount, maxBackoffMs, jitterMs);
+      log.info(
+          "Retrying resource creation with exponential backoff. "
+              + "Delay: {}ms, responseCode: {}, attempt: {}/{}",
+          actualDelay,
+          e.getCode(),
+          attemptCount,
+          maxAttempts);
+    }
     try {
       Thread.sleep(actualDelay);
     } catch (InterruptedException ex) {
       log.info("Backoff sleep interrupted, waking up early to retry resource creation");
       Thread.currentThread().interrupt();
     }
+  }
+
+  /**
+   * Extracts the server-requested retry delay, in milliseconds, from a Kubernetes API error
+   * response. The fabric8 client does not expose the raw {@code Retry-After} HTTP header, but
+   * the API server mirrors its value into {@code status.details.retryAfterSeconds} for
+   * rate-limited (429) and unavailable (503) responses, so that field is used instead.
+   *
+   * @param e the exception raised by the Kubernetes API call.
+   * @return the requested delay in milliseconds, or {@code null} if the server did not specify
+   *     one.
+   */
+  static Long getRetryAfterMillis(KubernetesClientException e) {
+    Status status = e.getStatus();
+    StatusDetails details = status == null ? null : status.getDetails();
+    Integer retryAfterSeconds = details == null ? null : details.getRetryAfterSeconds();
+    if (retryAfterSeconds == null || retryAfterSeconds <= 0) {
+      return null;
+    }
+    return TimeUnit.SECONDS.toMillis(retryAfterSeconds);
   }
 
   static long computeBackoffDelay(

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/ReconcilerUtils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/ReconcilerUtils.java
@@ -149,7 +149,7 @@ public final class ReconcilerUtils {
             throw e;
           }
           if (shouldBackoffBeforeRetry(e)) {
-            BackoffUtils.backoffSleep(e.getCode(), attemptCount, maxAttempts);
+            BackoffUtils.backoffSleep(e, attemptCount, maxAttempts);
           }
         }
       }
@@ -229,6 +229,9 @@ public final class ReconcilerUtils {
   }
 
   private static boolean shouldBackoffBeforeRetry(KubernetesClientException e) {
+    if (BackoffUtils.getRetryAfterMillis(e) != null) {
+      return true;
+    }
     return switch (e.getCode()) {
       case HTTP_CONFLICT, Constants.HTTP_TOO_MANY_REQUESTS -> true;
       default -> false;

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/BackoffUtilsTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/BackoffUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.junit.jupiter.api.Test;
+
+class BackoffUtilsTest {
+
+  @Test
+  void retryAfterMillisReturnsValueFromStatusDetails() {
+    KubernetesClientException e =
+        new KubernetesClientException(
+            "Too Many Requests",
+            429,
+            new StatusBuilder()
+                .withCode(429)
+                .withNewDetails()
+                .withRetryAfterSeconds(5)
+                .endDetails()
+                .build());
+
+    assertEquals(5000L, BackoffUtils.getRetryAfterMillis(e));
+  }
+
+  @Test
+  void retryAfterMillisReturnsNullWhenAbsent() {
+    KubernetesClientException e =
+        new KubernetesClientException(
+            "Too Many Requests", 429, new StatusBuilder().withCode(429).build());
+
+    assertNull(BackoffUtils.getRetryAfterMillis(e));
+  }
+
+  @Test
+  void retryAfterMillisReturnsNullWhenNonPositive() {
+    KubernetesClientException e =
+        new KubernetesClientException(
+            "Too Many Requests",
+            429,
+            new StatusBuilder()
+                .withCode(429)
+                .withNewDetails()
+                .withRetryAfterSeconds(0)
+                .endDetails()
+                .build());
+
+    assertNull(BackoffUtils.getRetryAfterMillis(e));
+  }
+
+  @Test
+  void retryAfterMillisReturnsNullWhenNoStatus() {
+    KubernetesClientException e = new KubernetesClientException("Too Many Requests", 429, null);
+
+    assertNull(BackoffUtils.getRetryAfterMillis(e));
+  }
+
+  @Test
+  void computeBackoffDelayCapsAtMaxAndAddsJitterWithinBounds() {
+    long delay = BackoffUtils.computeBackoffDelay(1000L, 2.0, 10, 40000L, 500L);
+    assertTrue(delay >= 40000L && delay <= 40500L);
+  }
+
+  @Test
+  void computeBackoffDelayGrowsExponentiallyBeforeCap() {
+    long delayAttempt2 = BackoffUtils.computeBackoffDelay(1000L, 2.0, 2, 40000L, 0L);
+    long delayAttempt3 = BackoffUtils.computeBackoffDelay(1000L, 2.0, 3, 40000L, 0L);
+    assertEquals(1000L, delayAttempt2);
+    assertEquals(2000L, delayAttempt3);
+  }
+}

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/ReconcilerUtilsTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/ReconcilerUtilsTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
@@ -129,5 +130,63 @@ class ReconcilerUtilsTest {
     assertThrows(
         KubernetesClientException.class,
         () -> ReconcilerUtils.getOrCreateSecondaryResource(mockClient, pod));
+  }
+
+  @Test
+  void retriesCreateOn429AndSucceedsHonoringRetryAfter() {
+    Pod pod = buildPod();
+    KubernetesClient mockClient = mock(KubernetesClient.class);
+    NamespaceableResource<Pod> mockResource = mockClientReturning(mockClient, pod);
+    when(mockResource.get()).thenReturn(null);
+    // server reports 1s Retry-After, mirrored into status.details.retryAfterSeconds
+    KubernetesClientException tooManyRequests =
+        new KubernetesClientException(
+            "Too Many Requests",
+            429,
+            new StatusBuilder()
+                .withCode(429)
+                .withNewDetails()
+                .withRetryAfterSeconds(1)
+                .endDetails()
+                .build());
+    // 1st CREATE -> 429; 2nd CREATE -> success
+    when(mockResource.create()).thenThrow(tooManyRequests).thenReturn(pod);
+
+    long start = System.nanoTime();
+    Optional<Pod> result = ReconcilerUtils.getOrCreateSecondaryResource(mockClient, pod);
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertTrue(result.isPresent());
+    assertTrue(elapsedMillis >= 1000L, "should have slept for the server-requested 1s");
+  }
+
+  @Test
+  void retriesCreateOnTransient5xxHonoringRetryAfterWhenPresent() {
+    Pod pod = buildPod();
+    KubernetesClient mockClient = mock(KubernetesClient.class);
+    NamespaceableResource<Pod> mockResource = mockClientReturning(mockClient, pod);
+    // resource never appears via GET, so the retry loop must go through backoffSleep
+    when(mockResource.get()).thenReturn(null);
+    // 503 is otherwise retried immediately, but a server-requested 1s Retry-After
+    // should still be honored before the next attempt
+    KubernetesClientException serviceUnavailable =
+        new KubernetesClientException(
+            "Service unavailable",
+            503,
+            new StatusBuilder()
+                .withCode(503)
+                .withNewDetails()
+                .withRetryAfterSeconds(1)
+                .endDetails()
+                .build());
+    // 1st CREATE -> 503; 2nd CREATE -> success
+    when(mockResource.create()).thenThrow(serviceUnavailable).thenReturn(pod);
+
+    long start = System.nanoTime();
+    Optional<Pod> result = ReconcilerUtils.getOrCreateSecondaryResource(mockClient, pod);
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+    assertTrue(result.isPresent());
+    assertTrue(elapsedMillis >= 1000L, "should have slept for the server-requested 1s");
   }
 }


### PR DESCRIPTION
…tion on Kubernetes API errors

### What changes were proposed in this pull request?

When ReconcilerUtils.getOrCreateSecondaryResource retries a failed secondary-resource creation, it now honors the server's requested retry delay instead of always using our own exponential backoff:

 - BackoffUtils.getRetryAfterMillis reads KubernetesClientException.getStatus().getDetails().getRetryAfterSeconds() — the field the Kubernetes API server mirrors from the HTTP Retry-After header into the response body (fabric8's client doesn't expose the raw header itself). When present and positive, BackoffUtils.backoffSleep sleeps for exactly that duration; otherwise it falls back to the existing jittered exponential backoff, unchanged.
 - ReconcilerUtils.shouldBackoffBeforeRetry now also returns true whenever a Retry-After value is present, regardless of status code — previously only 409 and 429 triggered a backoff sleep, so a transient 503 carrying retryAfterSeconds was retried immediately, ignoring the server's hint.

### Why are the changes needed?

 The server is in the best position to say how long to wait before retrying a throttled or overloaded request. Always using our own backoff schedule can retry too
 soon (extending throttling) or wait longer than necessary, and previously we ignored the hint entirely for non-429/409 errors like 503.

###  Does this PR introduce any user-facing change?

 No.

### How was this patch tested?

 Added BackoffUtilsTest covering getRetryAfterMillis (present/absent/non-positive/no-status cases) and computeBackoffDelay bounds. Added two tests in
 ReconcilerUtilsTest: retriesCreateOn429AndSucceedsHonoringRetryAfter (429 with retryAfterSeconds=1) and retriesCreateOnTransient5xxHonoringRetryAfterWhenPresent
 (503 with retryAfterSeconds=1), both asserting the retry succeeds and waited at least 1s.

###  Was this patch authored or co-authored using generative AI tooling?

 Co-Authored-by: Claude Code (claude-sonnet-5)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
